### PR TITLE
DDPB-1764: split Dockerfile and add a nightly Dockerfile.base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM registry.service.opg.digital/opguk/nginx:0.1.216
-
-RUN  apt-get update && apt-get autoclean && apt-get autoremove && rm -rf /var/lib/{apt,dpkg,cache,log}/ && rm -rf /tmp/* /var/tmp/*
+FROM registry.service.opg.digital/opguk/digi-deps-maintenance-base:nightly
 
 RUN rm /app/public/index.html
 ADD  . /app/public

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,3 @@
+FROM registry.service.opg.digital/opguk/nginx:0.1.216
+
+RUN  apt-get update && apt-get autoclean && apt-get autoremove && rm -rf /var/lib/{apt,dpkg,cache,log}/ && rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
See: ministryofjustice/opg-digi-deps-docker#61

This PR splits the Dockerfile into a nightly build using a Dockerfile.base and the normal build which will consume a FROM: nnnnn-base:nightly.